### PR TITLE
Remove fail code from title

### DIFF
--- a/Password Generator/script.js
+++ b/Password Generator/script.js
@@ -11,10 +11,6 @@ let passwordCopy = "";
 function generatePassword() {
   let allowedCharacters = [];
 
-  const title = "Password Generator";
-
-  title += "hola";
-
   if (document.querySelector("#use-upper").checked)
     allowedCharacters = allowedCharacters.concat(upperCaseLetters);
 


### PR DESCRIPTION
- Removed the code we used for demo purpose: `const title` 
![image](https://github.com/NPA93/Password-Generator/assets/55323504/00f72afc-79bc-4500-a298-6d3ff5b76b46)
